### PR TITLE
fix: fix always drawing wireframe in ShapesApp, chapter 7

### DIFF
--- a/src/Chapter 7 Drawing in Direct3D Part II/Shapes/ShapesApp.cpp
+++ b/src/Chapter 7 Drawing in Direct3D Part II/Shapes/ShapesApp.cpp
@@ -668,7 +668,7 @@ void ShapesApp::BuildPSOs()
 		mShaders["opaquePS"]->GetBufferSize()
 	};
 	opaquePsoDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-    opaquePsoDesc.RasterizerState.FillMode = D3D12_FILL_MODE_WIREFRAME;
+    opaquePsoDesc.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
 	opaquePsoDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
 	opaquePsoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
 	opaquePsoDesc.SampleMask = UINT_MAX;


### PR DESCRIPTION
I found that the app was always drawing in wireframe and this seems to be the cause. Sorry if this repo is not open for pull requests.